### PR TITLE
Email config default

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ With docker-compose installed, the project requires minimal setup
 ```bash
 git clone https://github.com/Nettverksdagen/Nettverksdagen-2.git
 cd Nettverksdagen-2
+cp api/nvdnew/settings/mail_settings_default.py api/nvdnew/settings/mail_settings.py
 docker-compose up
 ```
 The webpage should now appear on `localhost:8080` and the django REST api browser on `localhost:8000`. 

--- a/api/nvdnew/settings/mail_settings_default.py
+++ b/api/nvdnew/settings/mail_settings_default.py
@@ -1,0 +1,13 @@
+EMAIL_HOST = 'mail.uniweb.no'
+
+EMAIL_HOST_USER = 'do-not-reply@nettverksdagene.no'
+
+EMAIL_HOST_PASSWORD = ''
+
+EMAIL_PORT = '587'
+
+EMAIL_USE_TLS = True
+
+EMAIL_USE_SSL = False
+
+EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'


### PR DESCRIPTION
### Add default configuration file for emails. 
This is exactly the same file as in prod, but the password is removed doe to security reasons. It seems like (and it makes sense) that this does not change any behavior when running locally.  