### PR TITLE
Specify python version in api image

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.10
 ENV PYTHONUNBUFFERED 1
 ENV DJANGO_SETTINGS_MODULE=nvdnew.settings.prod
 RUN ["apt-get", "update"]


### PR DESCRIPTION
Psycopg2 does not seem to work in python 3.11. Specify python 3.10 to prevent the api from breaking again.