### PR TITLE
Allow postgres to initialize before attempting to restore database

### DIFF
--- a/nettverksdagen
+++ b/nettverksdagen
@@ -40,6 +40,7 @@ restart() {
 	local backup_time="$(backup)"
 	docker compose -f docker-compose-prod.yml down --volumes
 	docker compose -f docker-compose-prod.yml up --build --detach
+	sleep 10
 	restore "$backup_time"
 }
 
@@ -79,6 +80,7 @@ case $1 in
   restart)
 	backup_time="$(stop)"
 	start
+	sleep 10
 	restore "$backup_time" &> /dev/null
 	echo "$backup_time"
 	;;


### PR DESCRIPTION
After restarting, wait 10 seconds before restoring the database to allow postgres to initialize. This (mostly) fixes the issue where the database is completely empty after restarting.