### PR TITLE
Fix language inconsistency in translations

### DIFF
--- a/frontend/src/translations/en.json
+++ b/frontend/src/translations/en.json
@@ -58,7 +58,7 @@
     "hide": "Hide",
     "stillingstype": "Type of position",
     "sted": "Place",
-    "avslutningsmiddag": "avslutningsmiddag",
+    "avslutningsmiddag": "Formal Dinner",
     "ballongslipp": "Balloon drop",
     "standtext": "The hall will be filled with stands! Get in touch with many exciting companies.",
     "programtext": "Nettverksdagene will end with a formal dinner at Thon Hotel Prinsen. Click for info.",


### PR DESCRIPTION
Corrected the translation for "avslutningsmiddag" to "Formal Dinner" to ensure consistency in language usage.