### PR TITLE
Fix/hide non working unregister functionality

### DIFF
--- a/api/django-prod-entrypoint.sh
+++ b/api/django-prod-entrypoint.sh
@@ -3,4 +3,4 @@
 sh django-base-entrypoint.sh
 
 echo "Starting prod server"
-gunicorn --bind 0.0.0.0:8000 nvdnew.wsgi
+gunicorn --workers 3 --bind 0.0.0.0:8000 nvdnew.wsgi

--- a/api/nvdagen/viewsets.py
+++ b/api/nvdagen/viewsets.py
@@ -80,15 +80,14 @@ class ParticipantViewSet(viewsets.ModelViewSet):
                     data['header'] = program.header
                     html_message = render_to_string('registered_email.html', context=data)
                     plain_message = strip_tags(html_message)
-                    #Only for development to prevent email errors
-                    #send_mail('Nettverksdagene - Påmelding bekreftet for ' + data['name'],
-                    #    plain_message,
-                    #    'do-not-reply@nettverksdagene.no',
-                    #    [data['email']],
-                    #    fail_silently=False,
-                    #    html_message=html_message)
-            except:
-                print("ERROR: Could not send email. Is mail_settings.py correct?")
+                    send_mail('Nettverksdagene - Påmelding bekreftet for ' + data['name'],
+                       plain_message,
+                       'do-not-reply@nettverksdagene.no',
+                       [data['email']],
+                       fail_silently=False,
+                       html_message=html_message)
+            except Exception as e:
+                print("ERROR: Could not send email. Is mail_settings.py correct?", e)
                 response = {'message': 'Could not send email'}
                 return Response(response, status = status.HTTP_500_INTERNAL_SERVER_ERROR)                
 
@@ -115,8 +114,8 @@ class ParticipantViewSet(viewsets.ModelViewSet):
                 [participant.email],
                 fail_silently=False,
                 html_message=html_message)
-        except:
-            print("ERROR: Could not send email. Is mail_settings.py correct?")
+        except Exception as e:
+            print("ERROR: Could not send email. Is mail_settings.py correct?", e)
             response = {'message': 'Could not send email'}
             return Response(response, status = status.HTTP_500_INTERNAL_SERVER_ERROR)
 
@@ -124,7 +123,9 @@ class ParticipantViewSet(viewsets.ModelViewSet):
         return Response(response, status = status.HTTP_200_OK)
 
     def destroy(self, request, pk):
-        
+        # THIS METHOD IS UNSECURED AND SHOULD BE UPDATED
+        # CURRENTLY ANYONE CAN DELETE ANY PARTICIPANT AS LONG AS THEY KNOW THE ID
+
         participant = Participant.objects.get(id=pk)
 
         response = super().destroy(request)
@@ -149,8 +150,8 @@ class ParticipantViewSet(viewsets.ModelViewSet):
                             [lastParticipant.email],
                             fail_silently=False,
                             html_message=html_message)
-                    except:
-                        print("ERROR: Could not send email. Is mail_settings.py correct?")
+                    except Exception as e:
+                        print("ERROR: Could not send email. Is mail_settings.py correct?", e)
                         response = {'message': 'Could not send email'}
                         return Response(response, status = status.HTTP_500_INTERNAL_SERVER_ERROR)
 

--- a/api/nvdnew/templates/registered_email.html
+++ b/api/nvdnew/templates/registered_email.html
@@ -113,12 +113,13 @@
               Om du har spørsmål, ta kontakt med <a href = "mailto: bedrift@nettverksdagene.no">bedrift@nettverksdagene.no</a>
               <br> <br>Tusen takk for din interesse i Nettverksdagene 2025!
               <div class="border-bottom"></div>
-              <a class="subtle-link color" href="https://nettverksdagene.no/program">
+              <p>Ønsker du å melde deg av? Send en e-post til <a href="mailto:it@nettverksdagene.no">it@nettverksdagene.no</a>.</p>
+              <!-- Temporaraly removed until unregistration works. <a class="subtle-link color" href="https://nettverksdagene.no/program">
                   Trykk her
               </a>
-              <a class="subtle-link color no-decoration" href="https://nettverksdagene.no/program">
+              <a class="subtle-link color no-decoration" href="https://nettverksdagene.no/program/">
                   for å melde deg av arrangementet 
-              </a>
+              </a> -->
             </p>      
           </td>
         </tr> 

--- a/frontend/src/components/anon/ProgramItem.vue
+++ b/frontend/src/components/anon/ProgramItem.vue
@@ -40,7 +40,8 @@
             </div>
           </div>
           <div v-if="registration && cancelEmail">
-              <b-link @click.native="destroy_participant(name)">{{$t('destroypart')}}</b-link>
+              <div>{{$t('destroypart')}} <a href="mailto:it@nettverksdagene.no">it@nettverksdagene.no</a>.</div>
+              <!-- Removed temporaraly until unregistration works securely. <b-link @click.native="destroy_participant(name)">{{$t('destroypart')}}</b-link> -->
           </div>
           <div v-if="registration">
               <div v-if="submitted">
@@ -248,7 +249,7 @@ export default {
       }
       return true
     },
-    destroy_participant: function (event) {
+    /* Removed temporaraly until unregistration works SECURLY! THIS IS NOT SAFE! destroy_participant: function (event) {
       let email = prompt('Vennligst skriv inn emailen din:')
       let participants = this.$store.state.participant.all
       let participant = participants.filter(par => par.email === email && par.event === event)[0]
@@ -262,6 +263,7 @@ export default {
           let retry = true
           while (retry) {
             let inputedCode = prompt('Vennligst skriv inn koden som ble sendt til ' + participant.email + '. Hvis du ikke mottar mailen, vennligst kontakt IT-gruppen på it@nettverksdagene.no.')
+            // CLIENT SIDE CHECK????????? NOT SAFE! NOT SAFE! NOT SAFE!
             if (inputedCode === code) {
               if (confirm('Er du sikker på at du vil melde av ' + participant.name + '?')) {
                 axios.delete(process.env.VUE_APP_API_HOST + '/api/participant/' +
@@ -282,7 +284,7 @@ export default {
       } else if (email !== null) {
         alert('Fant ingen deltakere med denne epost-adressen på dette arrangementet.')
       }
-    }
+    }*/
   }
 }
 </script>

--- a/frontend/src/translations/en.json
+++ b/frontend/src/translations/en.json
@@ -24,7 +24,7 @@
     "regfinish": "Registration is finished",
     "påmeldte": "registered",
     "onthe": "on the",
-    "destroypart": "Do you wish to sign off, click here.",
+    "destroypart": "Do you wish to unregister? Send us an email at",
     "regtobegin": "Registration is starting",
     "avmelding": "Are you sure that you want to sign off?",
     "sponsors": "Sponsors in 2025",

--- a/frontend/src/translations/nb.json
+++ b/frontend/src/translations/nb.json
@@ -24,7 +24,7 @@
     "regfinish": "Påmelding er ferdig",
     "påmeldte": "påmeldte",
     "onthe": "på",
-    "destroypart": "Ønsker du å melde deg av? Klikk her.",
+    "destroypart": "Ønsker du å melde deg av? Send oss en e-post til",
     "regtobegin": "Påmelding starter",
     "avmelding": "Er du sikker på at du vil melde av",
     "sponsors": "Sponsorer i 2024",


### PR DESCRIPTION
Dette er en enkel PR som bare skjuler knappen for å melde seg selv av arrangementer. Den øker også antall tråder gunicorn kjører med i samme slengen for å ha bedre kapasitet for å håndtere påmelding. Jeg så også at bekreftelses e-postene var kommentert ut så de ble ikke sendt ut, dette har jeg endret tilbake. Git blame sier de ble kommentert ut ett år siden, lurer litt på hvorfor.