### PR TITLE
fix: remove-old-blogg-subdomain

### DIFF
--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -46,7 +46,7 @@ services:
       - GUID=1003
       - EMAIL=it@nettverksdagene.no
       - URL=nettverksdagene.no
-      - SUBDOMAINS=www,blogg
+      - SUBDOMAINS=www
       - TZ=Europe/Oslo
       - VALIDATION=http
       #- STAGING=true # Uncomment this when testing

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -46,7 +46,7 @@ services:
       - GUID=1003
       - EMAIL=it@nettverksdagene.no
       - URL=nettverksdagene.no
-      - SUBDOMAINS=www,blogg
+      - SUBDOMAINS=www
       - TZ=Europe/Oslo
       - VALIDATION=http
       #- STAGING=true # Uncomment this when testing


### PR DESCRIPTION
Removes the subdomain "blogg" from nginx as it is not used.