### PR TITLE
fix: don't run CI again after merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,5 @@
 name: CI
 on:
-  push:
-    branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
 jobs:


### PR DESCRIPTION
Fix: It is wasteful to run CI tests again after a PR is merged, so I tried to remove the on: push configuration.