### PR TITLE
job listing date fix

### DIFF
--- a/frontend/src/views/admin/AdminBaseView.vue
+++ b/frontend/src/views/admin/AdminBaseView.vue
@@ -87,7 +87,7 @@ export default {
           icon: 'cui-dollar'
         },
         {
-          name: 'Participants',
+          name: 'Deltakere',
           url: this.$router.resolve({name: 'ParticipantAdmin'}).href,
           icon: 'cui-dollar'
         }

--- a/frontend/src/views/admin/ListingAdminView.vue
+++ b/frontend/src/views/admin/ListingAdminView.vue
@@ -71,7 +71,7 @@
         </b-card>
       </div>
       <div class="d-none d-md-block col-4">
-        <b-jumbotron bg-variant="info" text-variant="white" :header="numListings + ''" lead="åpne stillingsannonser" class="h-100">
+        <b-jumbotron bg-variant="info" text-variant="white" :header="numActiveListings + ''" :lead="`åpne stillingsannonser. ${numListings} totalt.`" class="h-100">
           <hr class="my-4">
           <p>
             {{$t('herestilling')}}
@@ -165,6 +165,18 @@ export default {
     },
     numListings: function () {
       return this.listings.length
+    },
+    numActiveListings: function () {
+      const today = new Date()
+      today.setHours(0, 0, 0, 0) // Start of today
+
+      return this.listings.filter((listing) => {
+        if (!listing.deadline || listing.deadline == 0) return true // No deadline => active
+        const deadline = new Date(listing.deadline)
+        deadline.setHours(23, 59, 59, 999) // End of day
+
+        return today <= deadline
+      }).length
     },
     listingsLink: function () {
       return this.$router.resolve({name: 'Listings'})

--- a/frontend/src/views/admin/ListingAdminView.vue
+++ b/frontend/src/views/admin/ListingAdminView.vue
@@ -254,7 +254,9 @@ export default {
       this.$data.listing = listing
       this.$data.showImgPreview = true
       this.$data.editing = true
-      this.$data.deadlineDateTime = new Date(this.$data.listing.deadline)
+      this.$data.deadlineDateTime = listing.deadline ?  new Date(listing.deadline) : null
+      // Scroll to top when editing
+      window.scrollTo({top: 0, behavior: 'smooth'})
     },
     abortEdit: function () {
       this.resetForm()


### PR DESCRIPTION
This PR does the following:
- Fix bug where the deadline resets to 1970-01-01 when editing listings without deadline (ref #217 )
- Add automatic scrolling to the top when clicking "edit" on a job listing on admin page
- Rename "Participants" to "Deltakere" in admin sidebar to match language
- Change info-box in admin listings view to display active listings count (with deadline in the future) and grand total